### PR TITLE
remove `LD_LIBRARY_PATH` from env before `subprocess.check_output`

### DIFF
--- a/honey_installer/__init__.py
+++ b/honey_installer/__init__.py
@@ -1,1 +1,1 @@
-from installer import (HoneyInstaller, get_choice, get_version, Popen)
+from installer import (HoneyInstaller, get_choice, get_version, Popen, check_output)

--- a/honey_installer/installer.py
+++ b/honey_installer/installer.py
@@ -44,13 +44,13 @@ def replace_subprocess_env(**kwargs):
         env = kwargs[env]
     if env is None:
         env = os.environ
-
     env = {k:v for k,v in os.environ.iteritems() if k != 'LD_LIBRARY_PATH' and k != 'DYLD_LIBRARY_PATH'}
     kwargs['env'] = env
+    return kwargs
 
 def Popen(args, **kwargs):
     try:
-        replace_subprocess_env(**kwargs)
+        kwargs = replace_subprocess_env(**kwargs)
         p = subprocess.Popen(args, **kwargs)
     except OSError as e:
         click.echo("Failed to run {}: {}".format(args, e))
@@ -58,7 +58,7 @@ def Popen(args, **kwargs):
     return p
 
 def check_output(args, **kwargs):
-    replace_subprocess_env(**kwargs)
+    kwargs = replace_subprocess_env(**kwargs)
     return subprocess.check_output(args, **kwargs)
 
 def get_choice(choices, prompt):

--- a/honey_installer/installer.py
+++ b/honey_installer/installer.py
@@ -35,9 +35,9 @@ HONEYTAIL_URL = {
 
 TEAM_URL = "https://api.honeycomb.io/1/team_slug"
 
-    # this env hack is because pinstallers creates its own LD_LIBRARY_PATH
-    # which, when the script is run on a different linux distro, fails to load
-    # some libraries. This unsets it and gets around that problem.
+# this env hack is because pyinstallers creates its own LD_LIBRARY_PATH
+# which, when the script is run on a different linux distro, fails to load
+# some libraries. This unsets it and gets around that problem.
 def replace_subprocess_env(**kwargs):
     env = None
     if 'env' in kwargs:

--- a/nginx_installer/nginx_installer.py
+++ b/nginx_installer/nginx_installer.py
@@ -12,7 +12,7 @@ import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.basename(__file__), "..")))
 
-from honey_installer import (HoneyInstaller, get_version)
+from honey_installer import (HoneyInstaller, get_version, check_output)
 
 INSTALLER_NAME = "nginx"
 INSTALLER_VERSION = get_version() + "-" + platform.system().lower()
@@ -326,10 +326,16 @@ hit Enter to continue, 'n' to abort""", default=True):
 
     def _get_nginx_version(self):
         '''calls out to nginx -v to get the nginx version number (eg 1.4.2)'''
-        verstring = subprocess.check_output(["nginx", "-v"], stderr=subprocess.STDOUT)
-        version = verstring.split()[2]
-        vernum = version.split("/")[1]
-        return vernum
+        try:
+            verstring = check_output(["nginx", "-v"], stderr=subprocess.STDOUT)
+            version = verstring.split()[2]
+            vernum = version.split("/")[1]
+            return vernum
+        except subprocess.CalledProcessError as e:
+            self.warn("error checking nginx version (`{}`), exit status {}".format(e.cmd, e.returncode))
+            self.warn("output:")
+            self.warn(e.output)
+            return None
 
 @click.command()
 @click.option("--writekey", "-k", help="Your Honeycomb Writekey", default="")

--- a/nginx_installer/nginx_installer.py
+++ b/nginx_installer/nginx_installer.py
@@ -93,7 +93,12 @@ When you're ready to backfill, use the following command""".format(self.nginx_co
             access_log_name, access_log_format = self._get_access_log(found_logs, conf_loc, self.log_filename, self.log_format)
 
         ## Check the log_format and give recommendations
+        click.echo("Getting nginx version...")
         nginx_version = self._get_nginx_version()
+        if not nginx_version:
+            self.warn("assuming you're running nginx >= 1.0.0")
+            nginx_version = "1.0.0"
+
         if not log_formats:
             log_formats.append(["log_format", 'combined \'$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"\''])
             click.echo("It looks like you're using the default nginx configuration.")


### PR DESCRIPTION
Fixes #5 by using the same environment munging code as we already use for `Popen`.